### PR TITLE
Update cli.php

### DIFF
--- a/API/cli.php
+++ b/API/cli.php
@@ -218,7 +218,7 @@ error_reporting(E_ALL^E_NOTICE);
             }
 
 
-            $header = "D".$code.".".$this->protocol_version.".".strlen($arr).".".strlen($data).".";
+            $header = "D".$code.".".$this->protocol_version.".".strlen($arr ?? '').".".strlen($data ?? '').".";
             if($this->key)
             {
                 $header .= "1";


### PR DESCRIPTION
Fix of "Passing null to parameter #​1 ($string) of type string is depreciated" for php 8.*